### PR TITLE
feat(scp)!: remove deprecated denyServiceList in favor of scpBaselineStatements

### DIFF
--- a/API.md
+++ b/API.md
@@ -21566,7 +21566,6 @@ const dataLandingZoneProps: DataLandingZoneProps = { ... }
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.securityHubNotifications">securityHubNotifications</a></code> | <code><a href="#aws-data-landing-zone.SecurityHubNotification">SecurityHubNotification</a>[]</code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.additionalMandatoryTags">additionalMandatoryTags</a></code> | <code><a href="#aws-data-landing-zone.DlzTag">DlzTag</a>[]</code> | Extra tags appended to the five baseline mandatory tags (Owner, Project, Environment, CostCenter, Domain). |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.defaultNotification">defaultNotification</a></code> | <code><a href="#aws-data-landing-zone.NotificationDetailsProps">NotificationDetailsProps</a></code> | Default notification settings for the organization. |
-| <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.denyServiceList">denyServiceList</a></code> | <code>string[]</code> | List of services to deny in the organization SCP baseline. Empty by default — opt in to deny services. |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.deploymentPlatform">deploymentPlatform</a></code> | <code><a href="#aws-data-landing-zone.DeploymentPlatform">DeploymentPlatform</a></code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.finOps">finOps</a></code> | <code><a href="#aws-data-landing-zone.DlzFinOpsProps">DlzFinOpsProps</a></code> | Cost-management capabilities. |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.guardDuty">guardDuty</a></code> | <code><a href="#aws-data-landing-zone.DlzGuardDutyProps">DlzGuardDutyProps</a></code> | GuardDuty configuration for the organization. |
@@ -21678,24 +21677,6 @@ Allows you to define the
 email notfication settings or slack channel settings. If the account level defaultNotification
 is defined those will be used for the account instead of this defaultNotification which
 acts as the fallback.
-
----
-
-##### ~~`denyServiceList`~~<sup>Optional</sup> <a name="denyServiceList" id="aws-data-landing-zone.DataLandingZoneProps.property.denyServiceList"></a>
-
-- *Deprecated:* Use `scpBaselineStatements` for full control over the deny-services baseline. This field
-remains supported for the simple "deny these service actions" case.
-
-```typescript
-public readonly denyServiceList: string[];
-```
-
-- *Type:* string[]
-- *Default:* Defaults.denyServiceList() (empty list)
-
-List of services to deny in the organization SCP baseline. Empty by default — opt in to deny services.
-
-Cannot be used together with `scpBaselineStatements`.
 
 ---
 
@@ -21837,13 +21818,11 @@ public readonly scpBaselineStatements: PolicyStatement[];
 ```
 
 - *Type:* aws-cdk-lib.aws_iam.PolicyStatement[]
-- *Default:* default baseline derived from `denyServiceList`
+- *Default:* only the mandatory-tags SCP is applied
 
 Replaces the deny-services portion of the org SCP baseline applied to every workload account.
 
 The mandatory-tags SCP is always appended after these statements and cannot be opted out of.
-
-Cannot be used together with `denyServiceList`.
 
 ---
 
@@ -29964,7 +29943,6 @@ new Defaults()
 | <code><a href="#aws-data-landing-zone.Defaults.budgets">budgets</a></code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.Defaults.carbonEmissionsQueryColumns">carbonEmissionsQueryColumns</a></code> | Default query-column projection for `CARBON_EMISSIONS` exports. |
 | <code><a href="#aws-data-landing-zone.Defaults.corQueryColumns">corQueryColumns</a></code> | Default query-column projection for `COST_OPTIMIZATION_RECOMMENDATIONS` exports. |
-| <code><a href="#aws-data-landing-zone.Defaults.denyServiceList">denyServiceList</a></code> | * List of services that are denied in the organization. |
 | <code><a href="#aws-data-landing-zone.Defaults.focus12QueryColumns">focus12QueryColumns</a></code> | Default query-column projection for `FOCUS_1_2` exports. |
 | <code><a href="#aws-data-landing-zone.Defaults.guardDutyFeatures">guardDutyFeatures</a></code> | Default GuardDuty features. |
 | <code><a href="#aws-data-landing-zone.Defaults.iamIdentityCenterPermissionSets">iamIdentityCenterPermissionSets</a></code> | Provides the AWS managed policy `AdministratorAccess` and `ReadOnlyAccess` as permission sets. |
@@ -30031,18 +30009,6 @@ Defaults.corQueryColumns()
 Default query-column projection for `COST_OPTIMIZATION_RECOMMENDATIONS` exports.
 
 jsii-friendly accessor for the underlying `DLZ_COR_DEFAULT_QUERY_COLUMNS` constant.
-
-##### `denyServiceList` <a name="denyServiceList" id="aws-data-landing-zone.Defaults.denyServiceList"></a>
-
-```typescript
-import { Defaults } from 'aws-data-landing-zone'
-
-Defaults.denyServiceList()
-```
-
-* List of services that are denied in the organization.
-
-Empty by default — opt in to deny services.
 
 ##### `focus12QueryColumns` <a name="focus12QueryColumns" id="aws-data-landing-zone.Defaults.focus12QueryColumns"></a>
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,12 @@ const dlz = new DataLandingZone(app, {
       emails: ['you@org.com'],
     }),
   ],
-  denyServiceList: ['ecs:*'],
-  // For full control over the deny-services baseline, use scpBaselineStatements
-  // instead. Cannot be combined with denyServiceList. Mandatory-tags SCP is
-  // always appended after these statements.
+  // Optional: replace the deny-services portion of the org SCP baseline.
+  // The mandatory-tags SCP is always appended after these statements.
   // scpBaselineStatements: [
   //   ScpDenyRootUserActions.statement(),
   //   ScpDenyLeavingOrganization.statement(),
+  //   ScpDenyServiceActions.statement(['ecs:*']),
   // ],
   // SCP statements applied to every workload account of a given type, layered on
   // top of the org-wide baseline (deny-services + mandatory-tags SCP).
@@ -398,7 +397,7 @@ scp_statements_by_account_type=dlz.ScpStatementsByAccountType(
 
 | Preset | What it denies | Risk |
 |---|---|---|
-| `ScpDenyServiceActions(serviceActions)` | A caller-supplied list of service actions across all resources. Backs `DataLandingZoneProps.denyServiceList` (and the default deny-services portion of `scpBaselineStatements`). | 🟢 |
+| `ScpDenyServiceActions(serviceActions)` | A caller-supplied list of service actions across all resources. Compose into `scpBaselineStatements` to deny specific services org-wide. | 🟢 |
 | `ScpDenyCfnStacksWithoutStandardTags(tags)` | `cloudformation:CreateStack` unless every required tag is present. Backs the mandatory-tags SCP. | 🟡 |
 | `ScpDenyIamWithoutPermissionsBoundary` | Creating/modifying IAM users or roles unless the `IamPolicyPermissionBoundaryPolicy` boundary is attached (4 statements). Pairs with `iamPolicyPermissionBoundary` prop. | 🟡 |
 

--- a/docs/src/content/docs/components/security/scps.mdx
+++ b/docs/src/content/docs/components/security/scps.mdx
@@ -15,7 +15,7 @@ statements from a tier above it.
 
 | Tier              | Applies to                | Configured via                                          |
 |-------------------|---------------------------|---------------------------------------------------------|
-| Org baseline      | Every workload account    | `scpBaselineStatements` (or `denyServiceList`)          |
+| Org baseline      | Every workload account    | `scpBaselineStatements`                                 |
 | Per-account-type  | All accounts of one type  | `scpStatementsByAccountType.{development \| production}` |
 | Per-account       | One specific account      | `DLzAccount.scpStatements`                              |
 
@@ -222,50 +222,6 @@ Use `scpStatements` on a `DLzAccount` for one-off restrictions that only apply t
   </Fragment>
 </DualCode>
 
-## Service Deny List (legacy)
-
-Before the preset library was introduced, the `denyServiceList` property accepted a flat list of `service:action`
-strings to deny in the org baseline. It is still supported for the simple case but is **deprecated** in favor of
-`scpBaselineStatements` with `ScpDenyServiceActions`.
-
-`denyServiceList` and `scpBaselineStatements` cannot be used together — DLZ throws at synthesis time if both are set.
-
-<DualCode>
-  <Fragment slot="ts">
-    ```ts
-    import { App } from 'aws-cdk-lib';
-    import { DataLandingZone, Defaults } from 'aws-data-landing-zone';
-
-    const app = new App();
-    const dlz = new DataLandingZone(app, {
-      denyServiceList: [
-        ...Defaults.denyServiceList(),
-        'ecs:*',
-      ],
-     ...
-    });
-    ```
-  </Fragment>
-  <Fragment slot="python">
-    ```python
-    import aws_cdk as cdk
-    import aws_data_landing_zone as dlz
-
-    app = cdk.App()
-    dlz.DataLandingZone(app,
-        deny_service_list=[
-            *dlz.Defaults.deny_service_list(),
-            "ecs:*"
-        ],
-        ...
-    )
-    ```
-  </Fragment>
-</DualCode>
-
-The `Defaults.denyServiceList()` helper returns the conservative starter list. See the source
-[here](https://github.com/DataChefHQ/aws-data-landing-zone/blob/main/src/defaults.ts).
-
 ## Validation
 
 DLZ validates each account's resolved SCP at synthesis time and fails with a clear error if:
@@ -279,6 +235,5 @@ This catches misconfiguration before any CloudFormation deployment runs.
 ## API References
 - [DataLandingZoneProps.scpBaselineStatements](/reference/api/#aws-data-landing-zone.DataLandingZoneProps.property.scpBaselineStatements)
 - [DataLandingZoneProps.scpStatementsByAccountType](/reference/api/#aws-data-landing-zone.DataLandingZoneProps.property.scpStatementsByAccountType)
-- [DataLandingZoneProps.denyServiceList](/reference/api/#aws-data-landing-zone.DataLandingZoneProps.property.denyServiceList)
 - [DLzAccount.scpStatements](/reference/api/#aws-data-landing-zone.DLzAccount.property.scpStatements)
 - [ScpStatementsByAccountType](/reference/api/#aws-data-landing-zone.ScpStatementsByAccountType)

--- a/docs/src/content/docs/introduction.mdx
+++ b/docs/src/content/docs/introduction.mdx
@@ -182,10 +182,6 @@ approvals in production environments.
           }),
         ],
       },
-      denyServiceList: [
-        ...Defaults.denyServiceList(),
-        'ecs:*',
-      ],
       organization: {
         organizationId: 'o-0f5h921gk9',
         root: { accounts: { management: { accountId: '123456789012', }, }, },

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -21570,7 +21570,6 @@ const dataLandingZoneProps: DataLandingZoneProps = { ... }
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.securityHubNotifications">securityHubNotifications</a></code> | <code><a href="#aws-data-landing-zone.SecurityHubNotification">SecurityHubNotification</a>[]</code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.additionalMandatoryTags">additionalMandatoryTags</a></code> | <code><a href="#aws-data-landing-zone.DlzTag">DlzTag</a>[]</code> | Extra tags appended to the five baseline mandatory tags (Owner, Project, Environment, CostCenter, Domain). |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.defaultNotification">defaultNotification</a></code> | <code><a href="#aws-data-landing-zone.NotificationDetailsProps">NotificationDetailsProps</a></code> | Default notification settings for the organization. |
-| <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.denyServiceList">denyServiceList</a></code> | <code>string[]</code> | List of services to deny in the organization SCP baseline. Empty by default — opt in to deny services. |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.deploymentPlatform">deploymentPlatform</a></code> | <code><a href="#aws-data-landing-zone.DeploymentPlatform">DeploymentPlatform</a></code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.finOps">finOps</a></code> | <code><a href="#aws-data-landing-zone.DlzFinOpsProps">DlzFinOpsProps</a></code> | Cost-management capabilities. |
 | <code><a href="#aws-data-landing-zone.DataLandingZoneProps.property.guardDuty">guardDuty</a></code> | <code><a href="#aws-data-landing-zone.DlzGuardDutyProps">DlzGuardDutyProps</a></code> | GuardDuty configuration for the organization. |
@@ -21682,24 +21681,6 @@ Allows you to define the
 email notfication settings or slack channel settings. If the account level defaultNotification
 is defined those will be used for the account instead of this defaultNotification which
 acts as the fallback.
-
----
-
-##### ~~`denyServiceList`~~<sup>Optional</sup> <a name="denyServiceList" id="aws-data-landing-zone.DataLandingZoneProps.property.denyServiceList"></a>
-
-- *Deprecated:* Use `scpBaselineStatements` for full control over the deny-services baseline. This field
-remains supported for the simple "deny these service actions" case.
-
-```typescript
-public readonly denyServiceList: string[];
-```
-
-- *Type:* string[]
-- *Default:* Defaults.denyServiceList() (empty list)
-
-List of services to deny in the organization SCP baseline. Empty by default — opt in to deny services.
-
-Cannot be used together with `scpBaselineStatements`.
 
 ---
 
@@ -21841,13 +21822,11 @@ public readonly scpBaselineStatements: PolicyStatement[];
 ```
 
 - *Type:* aws-cdk-lib.aws_iam.PolicyStatement[]
-- *Default:* default baseline derived from `denyServiceList`
+- *Default:* only the mandatory-tags SCP is applied
 
 Replaces the deny-services portion of the org SCP baseline applied to every workload account.
 
 The mandatory-tags SCP is always appended after these statements and cannot be opted out of.
-
-Cannot be used together with `denyServiceList`.
 
 ---
 
@@ -29968,7 +29947,6 @@ new Defaults()
 | <code><a href="#aws-data-landing-zone.Defaults.budgets">budgets</a></code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.Defaults.carbonEmissionsQueryColumns">carbonEmissionsQueryColumns</a></code> | Default query-column projection for `CARBON_EMISSIONS` exports. |
 | <code><a href="#aws-data-landing-zone.Defaults.corQueryColumns">corQueryColumns</a></code> | Default query-column projection for `COST_OPTIMIZATION_RECOMMENDATIONS` exports. |
-| <code><a href="#aws-data-landing-zone.Defaults.denyServiceList">denyServiceList</a></code> | * List of services that are denied in the organization. |
 | <code><a href="#aws-data-landing-zone.Defaults.focus12QueryColumns">focus12QueryColumns</a></code> | Default query-column projection for `FOCUS_1_2` exports. |
 | <code><a href="#aws-data-landing-zone.Defaults.guardDutyFeatures">guardDutyFeatures</a></code> | Default GuardDuty features. |
 | <code><a href="#aws-data-landing-zone.Defaults.iamIdentityCenterPermissionSets">iamIdentityCenterPermissionSets</a></code> | Provides the AWS managed policy `AdministratorAccess` and `ReadOnlyAccess` as permission sets. |
@@ -30035,18 +30013,6 @@ Defaults.corQueryColumns()
 Default query-column projection for `COST_OPTIMIZATION_RECOMMENDATIONS` exports.
 
 jsii-friendly accessor for the underlying `DLZ_COR_DEFAULT_QUERY_COLUMNS` constant.
-
-##### `denyServiceList` <a name="denyServiceList" id="aws-data-landing-zone.Defaults.denyServiceList"></a>
-
-```typescript
-import { Defaults } from 'aws-data-landing-zone'
-
-Defaults.denyServiceList()
-```
-
-* List of services that are denied in the organization.
-
-Empty by default — opt in to deny services.
 
 ##### `focus12QueryColumns` <a name="focus12QueryColumns" id="aws-data-landing-zone.Defaults.focus12QueryColumns"></a>
 

--- a/docs/src/content/docs/reference/defaults.mdx
+++ b/docs/src/content/docs/reference/defaults.mdx
@@ -57,13 +57,10 @@ resources created by the DLZ:
 
 A comprehensive list of defaults referenced throughout the documentation:
 
-- [Defaults.denyServiceList](/components/security/scps#service-deny-list-legacy): Creates two budgets, one for the organization
 - [Defaults.budgets](/components/account-management/budgets#defaults): Creates two budgets, one for the organization
 and another for the DLZ-managed resources.
 - [Defaults.vpcClassB3Private3Public](/components/networking/vpcs#defaults): Creates a VPC with three public and three
 private subnets in the `eu-west-1` region.
-- [Defaults.denyServiceList](/components/security/scps#service-deny-list-legacy): Creates a list of services that should
-be denied by default.
 - [Defaults.rootControls](/components/security/control-tower-controls#defaults): Specifies a list of commonly used
 Control Tower Controls based on best practices and data management.
 - [Defaults.iamIdentityCenterPermissionSets](/components/identity/iam-identity-center) function creates two permission

--- a/src/data-landing-zone-types.ts
+++ b/src/data-landing-zone-types.ts
@@ -795,23 +795,10 @@ export interface DataLandingZoneProps {
   readonly iamIdentityCenter?: IamIdentityCenterProps;
 
   /**
-   * List of services to deny in the organization SCP baseline. Empty by default — opt in to deny services.
-   *
-   * Cannot be used together with `scpBaselineStatements`.
-   *
-   * @deprecated Use `scpBaselineStatements` for full control over the deny-services baseline. This field
-   * remains supported for the simple "deny these service actions" case.
-   * @default Defaults.denyServiceList() (empty list)
-   */
-  readonly denyServiceList?: string[];
-
-  /**
    * Replaces the deny-services portion of the org SCP baseline applied to every workload account.
    * The mandatory-tags SCP is always appended after these statements and cannot be opted out of.
    *
-   * Cannot be used together with `denyServiceList`.
-   *
-   * @default - default baseline derived from `denyServiceList`
+   * @default - only the mandatory-tags SCP is applied
    */
   readonly scpBaselineStatements?: PolicyStatement[];
 

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -11,10 +11,7 @@ import {
 import { DlzGuardDutyFeaturesProps } from './constructs/dlz-guardduty/guardduty-types';
 import { DlzMacieProps } from './constructs/dlz-macie/macie-types';
 import { DlzVpcProps } from './constructs/dlz-vpc/dlz-vpc';
-import {
-  ScpDenyCfnStacksWithoutStandardTags,
-  ScpDenyServiceActions,
-} from './constructs/organization-policies';
+import { ScpDenyCfnStacksWithoutStandardTags } from './constructs/organization-policies';
 import { DlzTag } from './constructs/organization-policies/tag-policy';
 
 import { DataLandingZoneProps, ForceNoPythonArgumentLifting, Region } from './data-landing-zone-types';
@@ -32,13 +29,6 @@ export enum IamIdentityPermissionSets {
 }
 
 export class Defaults {
-  /** *
-   * List of services that are denied in the organization. Empty by default — opt in to deny services.
-   */
-  public static denyServiceList(): string[] {
-    return [];
-  }
-
   /**
    * Creates a VPC configuration with 2 route tables, one used as public and the other private, each with 3 subnets.
    * Each subnet has a /19 CIDR block. The VPC CIDR is `10.${thirdOctetMask}.0.0/16`
@@ -286,23 +276,9 @@ export class PropsOrDefaults {
    * Owns conflict detection, deny-list resolution, and the always-appended mandatory-tags SCP.
    */
   public static getScpBaseline(props: DataLandingZoneProps): iam.PolicyStatement[] {
-    if (props.scpBaselineStatements !== undefined && props.denyServiceList !== undefined) {
-      throw new Error(
-        'DataLandingZoneProps: cannot set both `scpBaselineStatements` and `denyServiceList`. ' +
-        '`scpBaselineStatements` replaces the deny-services baseline; remove `denyServiceList`.',
-      );
-    }
-
     const tags = PropsOrDefaults.getOrganizationTags(props);
     const tagsStatement = ScpDenyCfnStacksWithoutStandardTags.statement(tags);
-
-    if (props.scpBaselineStatements !== undefined) {
-      return [...props.scpBaselineStatements, tagsStatement];
-    }
-
-    const denyList = props.denyServiceList ?? Defaults.denyServiceList();
-    const denies = denyList.length > 0 ? [ScpDenyServiceActions.statement(denyList)] : [];
-    return [...denies, tagsStatement];
+    return [...(props.scpBaselineStatements ?? []), tagsStatement];
   }
 
   public static getOrganizationTags(props: DataLandingZoneProps) {

--- a/test/__snapshots__/build.test.ts.snap
+++ b/test/__snapshots__/build.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Build Local snapshot testing: auditStacksGlobalTemplate snapshot 1`] = 
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-851725452335-eu-west-1",
-          "S3Key": "005da2f9476ce8a2c4b70e8f5865faaa7835ca0a0ff0ba8e5378a1e8fe87d551.zip",
+          "S3Key": "c2e811015266b66382390161e2c04d57c8831692780a563c7d3ca2ecec52c324.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -85,7 +85,7 @@ exports[`Build Local snapshot testing: auditStacksGlobalTemplate snapshot 1`] = 
       "Properties": {
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-851725452335-eu-west-1",
-          "S3Key": "3cfd5448ca3740c7b87360da84a4d869b9d2125ca61aaf714f09c709270dafc9.zip",
+          "S3Key": "3df72285f20033a52178fceb96c47269500a57389c74d7fdcce9f73ab643ba78.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,

--- a/test/__snapshots__/build.test.ts.snap
+++ b/test/__snapshots__/build.test.ts.snap
@@ -2780,22 +2780,6 @@ exports[`Build Local snapshot testing: managementTemplate snapshot 1`] = `
         "Content": {
           "Statement": [
             {
-              "Action": [
-                "eks:*",
-                "ecs:*",
-              ],
-              "Condition": {
-                "ArnNotLike": {
-                  "aws:PrincipalARN": [
-                    "arn:aws:iam::*:role/AWSControlTowerExecution",
-                  ],
-                },
-              },
-              "Effect": "Deny",
-              "Resource": "*",
-              "Sid": "DenyServiceActions",
-            },
-            {
               "Action": "cloudformation:CreateStack",
               "Condition": {
                 "Null": {
@@ -2838,22 +2822,6 @@ exports[`Build Local snapshot testing: managementTemplate snapshot 1`] = `
       "Properties": {
         "Content": {
           "Statement": [
-            {
-              "Action": [
-                "eks:*",
-                "ecs:*",
-              ],
-              "Condition": {
-                "ArnNotLike": {
-                  "aws:PrincipalARN": [
-                    "arn:aws:iam::*:role/AWSControlTowerExecution",
-                  ],
-                },
-              },
-              "Effect": "Deny",
-              "Resource": "*",
-              "Sid": "DenyServiceActions",
-            },
             {
               "Action": "cloudformation:CreateStack",
               "Condition": {

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -49,11 +49,6 @@ const configBase: DataLandingZoneProps = {
     global: Region.EU_WEST_1,
     regional: [Region.US_EAST_1],
   },
-  denyServiceList: [
-    ...Defaults.denyServiceList(),
-    'eks:*',
-    'ecs:*',
-  ],
   mandatoryTags: {
     owner: [],
     project: undefined,

--- a/test/scp-baseline-defaults.test.ts
+++ b/test/scp-baseline-defaults.test.ts
@@ -1,6 +1,6 @@
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { DataLandingZoneProps } from '../src/data-landing-zone-types';
-import { Defaults, PropsOrDefaults } from '../src/defaults';
+import { PropsOrDefaults } from '../src/defaults';
 
 const baseProps: Pick<DataLandingZoneProps, 'mandatoryTags'> = {
   mandatoryTags: {
@@ -18,41 +18,15 @@ const propsWith = (extra: Partial<DataLandingZoneProps>): DataLandingZoneProps =
 const findStatement = (statements: iam.PolicyStatement[], sid: string) =>
   statements.find(s => s.toJSON().Sid === sid);
 
-describe('Defaults.denyServiceList', () => {
-  test('default is an empty list', () => {
-    expect(Defaults.denyServiceList()).toEqual([]);
-  });
-});
-
 describe('PropsOrDefaults.getScpBaseline', () => {
   test('default path: only the mandatory-tags statement is emitted', () => {
     const result = PropsOrDefaults.getScpBaseline(propsWith({}));
 
     expect(result).toHaveLength(1);
     expect(findStatement(result, 'DenyCfnStacksWithoutStandardTags')).toBeDefined();
-    expect(findStatement(result, 'DenyServiceActions')).toBeUndefined();
   });
 
-  test('explicit denyServiceList: emits a deny-services statement plus mandatory tags', () => {
-    const result = PropsOrDefaults.getScpBaseline(propsWith({ denyServiceList: ['ecs:*'] }));
-
-    expect(result).toHaveLength(2);
-    const deny = findStatement(result, 'DenyServiceActions');
-    expect(deny).toBeDefined();
-    // CDK collapses single-element Action arrays to a string in JSON output.
-    expect(deny!.toJSON().Action).toEqual('ecs:*');
-    expect(findStatement(result, 'DenyCfnStacksWithoutStandardTags')).toBeDefined();
-  });
-
-  test('explicit empty denyServiceList: only the mandatory-tags statement is emitted', () => {
-    const result = PropsOrDefaults.getScpBaseline(propsWith({ denyServiceList: [] }));
-
-    expect(result).toHaveLength(1);
-    expect(findStatement(result, 'DenyServiceActions')).toBeUndefined();
-    expect(findStatement(result, 'DenyCfnStacksWithoutStandardTags')).toBeDefined();
-  });
-
-  test('scpBaselineStatements override: replaces deny-services, mandatory tags still appended', () => {
+  test('scpBaselineStatements override: caller statements come first, mandatory tags appended', () => {
     const customDeny = new iam.PolicyStatement({
       sid: 'DenyRootUser',
       effect: iam.Effect.DENY,
@@ -67,7 +41,6 @@ describe('PropsOrDefaults.getScpBaseline', () => {
 
     expect(result).toHaveLength(2);
     expect(findStatement(result, 'DenyRootUser')).toBeDefined();
-    expect(findStatement(result, 'DenyServiceActions')).toBeUndefined();
     expect(findStatement(result, 'DenyCfnStacksWithoutStandardTags')).toBeDefined();
   });
 
@@ -76,16 +49,5 @@ describe('PropsOrDefaults.getScpBaseline', () => {
 
     expect(result).toHaveLength(1);
     expect(findStatement(result, 'DenyCfnStacksWithoutStandardTags')).toBeDefined();
-  });
-
-  test('throws when both scpBaselineStatements and denyServiceList are set', () => {
-    expect(() =>
-      PropsOrDefaults.getScpBaseline(
-        propsWith({
-          scpBaselineStatements: [],
-          denyServiceList: ['ecs:*'],
-        }),
-      ),
-    ).toThrow(/cannot set both `scpBaselineStatements` and `denyServiceList`/);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: `DataLandingZoneProps.denyServiceList` and `Defaults.denyServiceList()` are removed. Callers should compose `ScpDenyServiceActions.statement([...])` into `scpBaselineStatements` instead. The mandatory-tags SCP continues to be appended automatically.