### PR TITLE
fix: scope mandatory-tag SCP Denies to the resource that receives the tags

### DIFF
--- a/API.md
+++ b/API.md
@@ -32218,7 +32218,9 @@ not in the baseline, so add it yourself.
 
 `statements()` returns one Deny per tag key on purpose: IAM joins keys in a single `Null` block with AND, so
 one combined statement would only deny when every tag is absent. Gate only actions that support
-`aws:RequestTag` at creation. The action-set constants below are composable (spread the ones you want into
+`aws:RequestTag` at creation, and note that supporting it is not sufficient on its own: actions
+authorized against more than one resource need their Deny scoped to the resource that receives
+the tags, or it fires on the untagged one — see {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}. The action-set constants below are composable (spread the ones you want into
 `statements()`) and were verified against the AWS Service Authorization Reference.
 
 #### Initializers <a name="Initializers" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.Initializer"></a>
@@ -32283,6 +32285,8 @@ Tag keys default to {@link DEFAULT_TAG_KEYS}.
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.DEFAULT_TAG_KEYS">DEFAULT_TAG_KEYS</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.IAM_TAG_ON_CREATE_ACTIONS">IAM_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | IAM create actions. |
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.INFRA_TAG_ON_CREATE_ACTIONS">INFRA_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | Networking, storage, and compute create actions. |
+| <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS">MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | Create actions whose authorization also evaluates a resource that is *not* the one being tagged: `ec2:CreateSubnet` is authorized against the VPC, `ec2:RunInstances` against the image and subnet, `ecs:CreateService` against the cluster. |
+| <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAGGED_ARNS">MULTI_RESOURCE_TAGGED_ARNS</a></code> | <code>string[]</code> | Taggable ARNs for {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}, as a single union: each action is only ever authorized against its own resource type, so the union cannot cross-apply. |
 
 ---
 
@@ -32351,6 +32355,37 @@ Deliberately excludes resources that AWS services auto-create, untagged, at runt
 auto-scaling groups). Those calls carry no `aws:RequestTag`, so gating them can't be
 satisfied and only breaks normal operation (e.g. Lambda logging, backups, EKS scaling).
 Catch tag gaps on those with AWS Config instead of an SCP.
+
+---
+
+##### `MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS`<sup>Required</sup> <a name="MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS"></a>
+
+```typescript
+public readonly MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS: string[];
+```
+
+- *Type:* string[]
+
+Create actions whose authorization also evaluates a resource that is *not* the one being tagged: `ec2:CreateSubnet` is authorized against the VPC, `ec2:RunInstances` against the image and subnet, `ecs:CreateService` against the cluster.
+
+`aws:RequestTag/*` is absent from those
+evaluations, so a `Resource: '*'` Deny matches unconditionally and blocks the call however it
+is tagged. {@link statements} scopes these to {@link MULTI_RESOURCE_TAGGED_ARNS} instead.
+
+---
+
+##### `MULTI_RESOURCE_TAGGED_ARNS`<sup>Required</sup> <a name="MULTI_RESOURCE_TAGGED_ARNS" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAGGED_ARNS"></a>
+
+```typescript
+public readonly MULTI_RESOURCE_TAGGED_ARNS: string[];
+```
+
+- *Type:* string[]
+
+Taggable ARNs for {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}, as a single union: each action is only ever authorized against its own resource type, so the union cannot cross-apply.
+
+Deliberately omits `volume/*` for `ec2:RunInstances` — an instance tagged without matching
+volume tag specifications would otherwise be denied on the volume evaluation.
 
 ---
 

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -32222,7 +32222,9 @@ not in the baseline, so add it yourself.
 
 `statements()` returns one Deny per tag key on purpose: IAM joins keys in a single `Null` block with AND, so
 one combined statement would only deny when every tag is absent. Gate only actions that support
-`aws:RequestTag` at creation. The action-set constants below are composable (spread the ones you want into
+`aws:RequestTag` at creation, and note that supporting it is not sufficient on its own: actions
+authorized against more than one resource need their Deny scoped to the resource that receives
+the tags, or it fires on the untagged one — see {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}. The action-set constants below are composable (spread the ones you want into
 `statements()`) and were verified against the AWS Service Authorization Reference.
 
 #### Initializers <a name="Initializers" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.Initializer"></a>
@@ -32287,6 +32289,8 @@ Tag keys default to {@link DEFAULT_TAG_KEYS}.
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.DEFAULT_TAG_KEYS">DEFAULT_TAG_KEYS</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.IAM_TAG_ON_CREATE_ACTIONS">IAM_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | IAM create actions. |
 | <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.INFRA_TAG_ON_CREATE_ACTIONS">INFRA_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | Networking, storage, and compute create actions. |
+| <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS">MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS</a></code> | <code>string[]</code> | Create actions whose authorization also evaluates a resource that is *not* the one being tagged: `ec2:CreateSubnet` is authorized against the VPC, `ec2:RunInstances` against the image and subnet, `ecs:CreateService` against the cluster. |
+| <code><a href="#aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAGGED_ARNS">MULTI_RESOURCE_TAGGED_ARNS</a></code> | <code>string[]</code> | Taggable ARNs for {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}, as a single union: each action is only ever authorized against its own resource type, so the union cannot cross-apply. |
 
 ---
 
@@ -32355,6 +32359,37 @@ Deliberately excludes resources that AWS services auto-create, untagged, at runt
 auto-scaling groups). Those calls carry no `aws:RequestTag`, so gating them can't be
 satisfied and only breaks normal operation (e.g. Lambda logging, backups, EKS scaling).
 Catch tag gaps on those with AWS Config instead of an SCP.
+
+---
+
+##### `MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS`<sup>Required</sup> <a name="MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS"></a>
+
+```typescript
+public readonly MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS: string[];
+```
+
+- *Type:* string[]
+
+Create actions whose authorization also evaluates a resource that is *not* the one being tagged: `ec2:CreateSubnet` is authorized against the VPC, `ec2:RunInstances` against the image and subnet, `ecs:CreateService` against the cluster.
+
+`aws:RequestTag/*` is absent from those
+evaluations, so a `Resource: '*'` Deny matches unconditionally and blocks the call however it
+is tagged. {@link statements} scopes these to {@link MULTI_RESOURCE_TAGGED_ARNS} instead.
+
+---
+
+##### `MULTI_RESOURCE_TAGGED_ARNS`<sup>Required</sup> <a name="MULTI_RESOURCE_TAGGED_ARNS" id="aws-data-landing-zone.ScpDenyResourceCreationWithoutStandardTags.property.MULTI_RESOURCE_TAGGED_ARNS"></a>
+
+```typescript
+public readonly MULTI_RESOURCE_TAGGED_ARNS: string[];
+```
+
+- *Type:* string[]
+
+Taggable ARNs for {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}, as a single union: each action is only ever authorized against its own resource type, so the union cannot cross-apply.
+
+Deliberately omits `volume/*` for `ec2:RunInstances` — an instance tagged without matching
+volume tag specifications would otherwise be denied on the volume evaluation.
 
 ---
 

--- a/src/constructs/organization-policies/scp-presets/deny-resource-creation-without-standard-tags.ts
+++ b/src/constructs/organization-policies/scp-presets/deny-resource-creation-without-standard-tags.ts
@@ -19,7 +19,9 @@ export interface ScpDenyResourceCreationTagOptions {
  *
  * `statements()` returns one Deny per tag key on purpose: IAM joins keys in a single `Null` block with AND, so
  * one combined statement would only deny when every tag is absent. Gate only actions that support
- * `aws:RequestTag` at creation. The action-set constants below are composable (spread the ones you want into
+ * `aws:RequestTag` at creation, and note that supporting it is not sufficient on its own: actions
+ * authorized against more than one resource need their Deny scoped to the resource that receives
+ * the tags, or it fires on the untagged one — see {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}. The action-set constants below are composable (spread the ones you want into
  * `statements()`) and were verified against the AWS Service Authorization Reference.
  */
 export class ScpDenyResourceCreationWithoutStandardTags {
@@ -101,6 +103,37 @@ export class ScpDenyResourceCreationWithoutStandardTags {
     'iam:CreatePolicy',
   ];
 
+  /**
+   * Create actions whose authorization also evaluates a resource that is *not* the one being
+   * tagged: `ec2:CreateSubnet` is authorized against the VPC, `ec2:RunInstances` against the image
+   * and subnet, `ecs:CreateService` against the cluster. `aws:RequestTag/*` is absent from those
+   * evaluations, so a `Resource: '*'` Deny matches unconditionally and blocks the call however it
+   * is tagged. {@link statements} scopes these to {@link MULTI_RESOURCE_TAGGED_ARNS} instead.
+   */
+  public static readonly MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS: string[] = [
+    'ec2:RunInstances',
+    'ec2:CreateSubnet',
+    'ec2:CreateNatGateway',
+    'ecs:CreateService',
+    'eks:CreateNodegroup',
+    'eks:CreateFargateProfile',
+  ];
+
+  /**
+   * Taggable ARNs for {@link MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS}, as a single union: each action
+   * is only ever authorized against its own resource type, so the union cannot cross-apply.
+   * Deliberately omits `volume/*` for `ec2:RunInstances` — an instance tagged without matching
+   * volume tag specifications would otherwise be denied on the volume evaluation.
+   */
+  public static readonly MULTI_RESOURCE_TAGGED_ARNS: string[] = [
+    'arn:aws:ec2:*:*:instance/*',
+    'arn:aws:ec2:*:*:subnet/*',
+    'arn:aws:ec2:*:*:natgateway/*',
+    'arn:aws:ecs:*:*:service/*',
+    'arn:aws:eks:*:*:nodegroup/*',
+    'arn:aws:eks:*:*:fargateprofile/*',
+  ];
+
   /** One Deny per tag key over `actions`. Tag keys default to {@link DEFAULT_TAG_KEYS}. */
   public static statements(
     actions: string[],
@@ -115,11 +148,15 @@ export class ScpDenyResourceCreationWithoutStandardTags {
       ? { BoolIfExists: { 'aws:ViaAWSService': 'false' } }
       : {};
 
-    return keys.map((key) => new iam.PolicyStatement({
-      sid: `DenyCreateWithout${key.replace(/[^a-zA-Z0-9]/g, '')}Tag`,
+    const multiResource = ScpDenyResourceCreationWithoutStandardTags.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS;
+    const scoped = actions.filter((action) => multiResource.includes(action));
+    const unscoped = actions.filter((action) => !multiResource.includes(action));
+
+    const deny = (sid: string, denyActions: string[], resources: string[], key: string) => new iam.PolicyStatement({
+      sid,
       effect: iam.Effect.DENY,
-      actions,
-      resources: ['*'],
+      actions: denyActions,
+      resources,
       conditions: {
         ...ControlTowerExemption.arnNotLike(),
         ...viaServiceExemption,
@@ -127,6 +164,21 @@ export class ScpDenyResourceCreationWithoutStandardTags {
           [`aws:RequestTag/${key}`]: true,
         },
       },
-    }));
+    });
+
+    return keys.flatMap((key) => {
+      const sid = key.replace(/[^a-zA-Z0-9]/g, '');
+      return [
+        ...(unscoped.length > 0 ? [deny(`DenyCreateWithout${sid}Tag`, unscoped, ['*'], key)] : []),
+        ...(scoped.length > 0
+          ? [deny(
+            `DenyCreateWithout${sid}TagScoped`,
+            scoped,
+            ScpDenyResourceCreationWithoutStandardTags.MULTI_RESOURCE_TAGGED_ARNS,
+            key,
+          )]
+          : []),
+      ];
+    });
   }
 }

--- a/test/scp-presets.test.ts
+++ b/test/scp-presets.test.ts
@@ -183,7 +183,7 @@ describe('SCP presets', () => {
   });
 
   test('ScpDenyResourceCreationWithoutStandardTags emits one presence Deny per tag key by default', () => {
-    const statements = ScpDenyResourceCreationWithoutStandardTags.statements(['ec2:RunInstances']);
+    const statements = ScpDenyResourceCreationWithoutStandardTags.statements(['ec2:CreateVolume']);
     expect(statements).toHaveLength(ScpDenyResourceCreationWithoutStandardTags.DEFAULT_TAG_KEYS.length);
 
     const sids = statements.map(s => s.toJSON().Sid);
@@ -198,7 +198,7 @@ describe('SCP presets', () => {
     for (const statement of statements) {
       const json = statement.toJSON();
       expect(json.Effect).toBe('Deny');
-      expect(json.Action).toBe('ec2:RunInstances');
+      expect(json.Action).toBe('ec2:CreateVolume');
       expect(json.Condition?.ArnNotLike?.['aws:PrincipalARN']).toContain(CT_ROLE);
     }
 
@@ -208,7 +208,7 @@ describe('SCP presets', () => {
 
   test('ScpDenyResourceCreationWithoutStandardTags honours a custom tag-key list', () => {
     const statements = ScpDenyResourceCreationWithoutStandardTags.statements(
-      ['ec2:RunInstances'],
+      ['ec2:CreateVolume'],
       ['Owner', 'team:name'],
     );
     expect(statements.map(s => s.toJSON().Sid)).toEqual([
@@ -219,15 +219,52 @@ describe('SCP presets', () => {
   });
 
   test('ScpDenyResourceCreationWithoutStandardTags omits aws:ViaAWSService by default', () => {
-    const [statement] = ScpDenyResourceCreationWithoutStandardTags.statements(['ec2:RunInstances']);
+    const [statement] = ScpDenyResourceCreationWithoutStandardTags.statements(['ec2:CreateVolume']);
     expect(statement.toJSON().Condition?.BoolIfExists).toBeUndefined();
   });
 
   test('ScpDenyResourceCreationWithoutStandardTags exempts service-forwarded calls when opted in', () => {
     const [statement] = ScpDenyResourceCreationWithoutStandardTags.statements(
-      ['ec2:RunInstances'], undefined, { exemptAwsServiceCalls: true },
+      ['ec2:CreateVolume'], undefined, { exemptAwsServiceCalls: true },
     );
     expect(statement.toJSON().Condition?.BoolIfExists).toEqual({ 'aws:ViaAWSService': 'false' });
+  });
+
+  test('ScpDenyResourceCreationWithoutStandardTags scopes multi-resource actions to the tagged ARNs', () => {
+    const statements = ScpDenyResourceCreationWithoutStandardTags.statements(['ec2:CreateSubnet'], ['Owner']);
+
+    expect(statements).toHaveLength(1);
+    const json = statements[0].toJSON();
+    expect(json.Sid).toBe('DenyCreateWithoutOwnerTagScoped');
+    expect(json.Resource).toEqual(ScpDenyResourceCreationWithoutStandardTags.MULTI_RESOURCE_TAGGED_ARNS);
+    expect(json.Resource).not.toContain('*');
+    expect(json.Condition?.Null?.['aws:RequestTag/Owner']).toBe(true);
+  });
+
+  test('ScpDenyResourceCreationWithoutStandardTags never puts a multi-resource action under Resource *', () => {
+    const all = [
+      ...ScpDenyResourceCreationWithoutStandardTags.CORE_TAG_ON_CREATE_ACTIONS,
+      ...ScpDenyResourceCreationWithoutStandardTags.DATA_PLATFORM_TAG_ON_CREATE_ACTIONS,
+      ...ScpDenyResourceCreationWithoutStandardTags.INFRA_TAG_ON_CREATE_ACTIONS,
+      ...ScpDenyResourceCreationWithoutStandardTags.IAM_TAG_ON_CREATE_ACTIONS,
+    ];
+    const statements = ScpDenyResourceCreationWithoutStandardTags.statements(all, ['Owner']);
+
+    // One unscoped Deny plus one scoped Deny, per tag key.
+    expect(statements).toHaveLength(2);
+    const wildcard = statements.map(s => s.toJSON()).find(j => j.Resource === '*' || j.Resource?.includes('*'))!;
+    for (const action of ScpDenyResourceCreationWithoutStandardTags.MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS) {
+      expect(wildcard.Action).not.toContain(action);
+    }
+  });
+
+  test('ScpDenyResourceCreationWithoutStandardTags emits only the wildcard Deny for single-resource actions', () => {
+    const statements = ScpDenyResourceCreationWithoutStandardTags.statements(
+      ScpDenyResourceCreationWithoutStandardTags.IAM_TAG_ON_CREATE_ACTIONS, ['Owner'],
+    );
+    expect(statements).toHaveLength(1);
+    expect(statements[0].toJSON().Sid).toBe('DenyCreateWithoutOwnerTag');
+    expect(statements[0].toJSON().Resource).toBe('*');
   });
 
   test('ScpDenyResourceCreationWithoutStandardTags INFRA list excludes service-auto-created actions', () => {


### PR DESCRIPTION
## Problem

`ScpDenyResourceCreationWithoutStandardTags.statements()` emits every Deny with `resources: ['*']`. That is only correct for actions authorized against a single resource.

Actions authorized against **more than one** resource are evaluated once per resource, and `aws:RequestTag/*` is only present in the evaluation for the resource actually being tagged. For the others the `Null` check reads "tag missing" and the Deny fires — so the call is blocked no matter how it is tagged. The preset becomes unsatisfiable rather than enforcing.

## Evidence

Hit on a live account (`p-nhty3x02`). A Terraform run failed on all nine subnets, so I reproduced it by hand with every mandatory tag in the request:

```
aws ec2 create-subnet --vpc-id vpc-… --cidr-block 10.10.250.0/28 \
  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,…},{Key=CostCenter,…},{Key=Project,…},{Key=Environment,…},{Key=Owner,…}]'
→ UnauthorizedOperation, explicit deny
```

Decoding that authorization message:

```
explicitDeny: True
matched: all 5 DenyCreateWithout*Tag statements
resource evaluated: arn:aws:ec2:…:vpc/vpc-…      ← the VPC, not the subnet
RequestTag keys in context: NONE
```

`ec2:CreateVpc` in the same run succeeded and came out correctly tagged, which is why only the multi-resource actions are affected.

## Fix

Split the gated actions into two Denies per tag key:

- single-resource actions keep `Resource: '*'`
- `MULTI_RESOURCE_TAG_ON_CREATE_ACTIONS` get a `…TagScoped` Deny restricted to `MULTI_RESOURCE_TAGGED_ARNS`

Enforcement is unchanged — an untagged create still matches the `Null` check on its own resource. Only the unsatisfiable evaluation goes away.

Two deliberate calls:

- **The ARN union is safe.** An action is only ever authorized against its own resource type, so listing all six ARNs in one statement cannot cross-apply.
- **`volume/*` is excluded** from the `RunInstances` scope. An instance tagged without matching volume tag specifications would otherwise be denied on the volume evaluation — the same bug in a new place.

## ⚠️ Size — needs an operator decision

SCP documents cap at **10,240 characters**. With the full action set (CORE + DATA_PLATFORM + INFRA + IAM):

| | size | |
|---|---|---|
| before (5 statements) | 8,027 | fits |
| after (10 statements) | 10,266 | **26 over** |
| after, split across two policies | 7,377 + 2,927 | both fit |

So callers spreading all four action sets into a single policy must split the two statement groups across two SCPs (quota is 10 per target), or trim the action list. Happy to add a helper that partitions them if you'd prefer that over a doc note.

## Verification

- `npx projen compile` — clean
- `npx projen eslint` — clean
- `npx jest` — 318 passed. `test/build.test.ts` fails identically on unmodified `main` (bundled-lambda asset hashes vs the committed snapshot), so it is pre-existing and not from this change.
- `test/scp-presets.test.ts` — 36 passed, 100% coverage on the touched file

Four existing tests used `ec2:RunInstances` purely as a sample action; since it is now scoped, they point at `ec2:CreateVolume` to keep testing what they meant to. Three new tests cover the scoping, the wildcard group never containing a multi-resource action, and single-resource action sets still emitting only the wildcard Deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
